### PR TITLE
included JsonIgnore in GeocodeResponse status

### DIFF
--- a/src/GeocodeSharp/Google/GeocodeResponse.cs
+++ b/src/GeocodeSharp/Google/GeocodeResponse.cs
@@ -7,6 +7,7 @@ namespace GeocodeSharp.Google
         [JsonProperty("results")]
         public GeocodeResult[] Results { get; set; }
 
+        [JsonIgnore]
         public GeocodeStatus Status
         {
             get


### PR DESCRIPTION
You can alter the global JsonConvert behaviour in Json.Net and this can leads to problems when serializing the GeocodeResponse like 

A member with the name "status" already exists on "GeocodeSharp.Google.GeocodeResponse". Use the JsonPropertyAttribute to specify another name.