### PR TITLE
Add ampersand to the ctor that takes the API key.

### DIFF
--- a/src/GeocodeSharp/Google/GeocodeClient.cs
+++ b/src/GeocodeSharp/Google/GeocodeClient.cs
@@ -28,7 +28,7 @@ namespace GeocodeSharp.Google
         public GeocodeClient(string apiKey)
         {
             _apiKey = apiKey;
-            _baseUrl = string.Format("https://maps.googleapis.com/maps/api/geocode/json?key={0}", Uri.EscapeDataString(_apiKey));
+            _baseUrl = string.Format("https://maps.googleapis.com/maps/api/geocode/json?key={0}&", Uri.EscapeDataString(_apiKey));
             var builder = new StringBuilder();
         }
 


### PR DESCRIPTION
Add ampersand to ctor that takes API key, otherwise the url that is generated will be incorrect when an api key is specified.