### PR TITLE
Added the ability to HMAC sign the api call using googles API for Wor…

### DIFF
--- a/src/GeocodeSharp.Tests/Google/GeocodeClientTest.cs
+++ b/src/GeocodeSharp.Tests/Google/GeocodeClientTest.cs
@@ -38,6 +38,20 @@ namespace GeocodeSharp.Tests.Google
         }
 
         [TestMethod]
+        [Ignore]  // Unignore after adding client credentials.
+        public async Task TestGeocodeAddressWithPartialMatchWithApiForWork()
+        {
+            var clientId = "[ADD-CLIENT-ID-HERE]";
+            var cryptoKey = "[ADD-CRYPTO_KEY_HERE]";;
+            const string address = "21 Henr St, Bristol, UK";
+            var client = new GeocodeClient(clientId, cryptoKey);
+            var result = await client.GeocodeAddress(address);
+            Assert.AreEqual(GeocodeStatus.Ok, result.Status);
+            Assert.AreEqual(true, result.Results.All(r => r.PartialMatch));
+            Assert.AreEqual(true, result.Results.Length > 0);
+        }
+        
+        [TestMethod]
         public async Task TestTestGeocodeAddressWithExactMatch()
         {
             const string address = "21 Henrietta St, Bristol, UK";

--- a/src/GeocodeSharp/GeocodeSharp.csproj
+++ b/src/GeocodeSharp/GeocodeSharp.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Google\GeoViewport.cs" />
     <Compile Include="Google\IGeocodeClient.cs" />
     <Compile Include="Google\LocationType.cs" />
+    <Compile Include="Google\UsageMode.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GeocodeSharp/Google/UsageMode.cs
+++ b/src/GeocodeSharp/Google/UsageMode.cs
@@ -1,0 +1,9 @@
+﻿namespace GeocodeSharp.Google
+{
+    public enum UsageMode
+    {
+        Free,
+        ClientKey,
+        ApiForWork
+    };
+}


### PR DESCRIPTION
I needed the ability to use our API for Work credentials. This means that the URL needs to be hashed with a crypto key to provide a signature.

I simply added another constructor and the notion of a usage mode i.e. free, key or work api (currently just auto set based on which constructor is called.)

Anyway, it works :-) and I thought you may like it for the product.