### PR TITLE
feat/20 Add support for System.Text.Json attributes

### DIFF
--- a/src/GeocodeSharp.Tests/GeocodeSharp.Tests.csproj
+++ b/src/GeocodeSharp.Tests/GeocodeSharp.Tests.csproj
@@ -4,6 +4,7 @@
     <Copyright>Copyright ©  2014</Copyright>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/GeocodeSharp.Tests/Serialization/SerializationTest.cs
+++ b/src/GeocodeSharp.Tests/Serialization/SerializationTest.cs
@@ -1,9 +1,111 @@
 ﻿using GeocodeSharp.Google;
+using System.Linq;
 using System.Reflection;
 using Xunit;
 
 namespace GeocodeSharp.Tests.Serialization {
   public class SerializationTest {
+    private static readonly GeocodeResponse ResponseMock = new GeocodeResponse {
+      Results = new[] {
+        new GeocodeResult {
+          AddressComponents =  new []{
+            new AddressComponent {
+              LongName = "My Long Name",
+              ShortName = "My Short Name",
+              Types = new [] {"type1", "type2"}
+            }
+          },
+          FormattedAddress = "My Formatted Address",
+          Geometry = new Geometry {
+            Bounds = new GeoViewport {
+              Northeast = new GeoCoordinate {Latitude = 0, Longitude=1},
+              Southwest = new GeoCoordinate { Latitude = 1, Longitude=2}
+            },
+            Location = new GeoCoordinate {Latitude = 51, Longitude=-1},
+            LocationTypeText = "My Location Type",
+            Viewport  = new GeoViewport {
+              Northeast = new GeoCoordinate {Latitude = 10, Longitude=11},
+              Southwest = new GeoCoordinate { Latitude = 11, Longitude=12}
+            }
+          },
+          PartialMatch = true,
+          PlaceId = "My Place ID",
+          Types = new[] {"type1", "type2", "type3"},
+        }
+      },
+      StatusText = "OK",
+    };
+
+    private T SerializeAndDeserialize<T>(T value) {
+      var json = Newtonsoft.Json.JsonConvert.SerializeObject(value);
+
+      return System.Text.Json.JsonSerializer.Deserialize<T>(json);
+    }
+
+    [Fact]
+    public void TestAddressComponentSerialization() {
+      var expected = ResponseMock.Results.First().AddressComponents.First();
+      var actual = SerializeAndDeserialize(expected);
+
+      Assert.Equal(expected.LongName, actual.LongName);
+      Assert.Equal(expected.ShortName, actual.ShortName);
+      Assert.Equal(expected.Types, actual.Types);
+    }
+
+    [Fact]
+    public void TestGeocodeResponseSerialization() {
+      var expected = ResponseMock;
+      var actual = SerializeAndDeserialize(expected);
+
+      Assert.Equal(expected.StatusText, actual.StatusText);
+      Assert.NotEmpty(actual.Results); // Tested by TestGeocodeResultSerialization
+    }
+
+    [Fact]
+    public void TestGeocodeResultSerialization() {
+      var expected = ResponseMock.Results.First();
+      var actual = SerializeAndDeserialize(expected);
+
+      Assert.NotEmpty(actual.AddressComponents); // Tested by TestAddressComponentSerialization
+      Assert.Equal(expected.FormattedAddress, actual.FormattedAddress);
+      Assert.NotNull(actual.Geometry); // Tested by TestGeometrySerialization
+      Assert.Equal(expected.PartialMatch, actual.PartialMatch);
+      Assert.Equal(expected.PlaceId, actual.PlaceId);
+      Assert.Equal(expected.Types, actual.Types);
+    }
+
+    [Fact]
+    public void TestGeoCoordinateSerialization() {
+      var expected = ResponseMock.Results.First().Geometry.Location;
+      var actual = SerializeAndDeserialize(expected);
+
+      Assert.Equal(expected.Latitude, actual.Latitude);
+      Assert.Equal(expected.Longitude, actual.Longitude);
+    }
+
+    [Fact]
+    public void TestGeometrySerialization() {
+      var expected = ResponseMock.Results.First().Geometry;
+      var actual = SerializeAndDeserialize(expected);
+
+      Assert.NotNull(actual.Bounds); // Tested by TestGeoViewportSerialization
+      Assert.NotNull(actual.Location); // Tested by TestGeoCoordinateSerialization
+      Assert.Equal(expected.LocationTypeText, actual.LocationTypeText);
+      Assert.Equal(expected.LocationType, actual.LocationType);
+      Assert.NotNull(actual.Viewport); // Tested by TestGeoViewportSerialization
+    }
+
+    [Fact]
+    public void TestGeoViewportSerialization() {
+      var expected = ResponseMock.Results.First().Geometry.Viewport;
+      var actual = SerializeAndDeserialize(expected);
+
+      Assert.Equal(expected.Northeast.Latitude, actual.Northeast.Latitude);
+      Assert.Equal(expected.Northeast.Longitude, actual.Northeast.Longitude);
+      Assert.Equal(expected.Southwest.Latitude, actual.Southwest.Latitude);
+      Assert.Equal(expected.Southwest.Longitude, actual.Southwest.Longitude);
+    }
+
     [Fact]
     public void TestJsonPropertyNames() {
       var allTypes = typeof(AddressComponent).Assembly.GetTypes();
@@ -18,8 +120,8 @@ namespace GeocodeSharp.Tests.Serialization {
           Assert.False(newtonName != null && txtName == null, $"{t.FullName}.{prop.Name} only has a Newtonsoft.Json.JsonPropertyAttribute");
           Assert.False(txtName != null && newtonName == null, $"{t.FullName}.{prop.Name} only has a System.Text.Json.Serialization.JsonPropertyNameAttribute");
           Assert.True(newtonName?.PropertyName == txtName?.Name, $"{t.FullName}.{prop.Name} expected '{newtonName?.PropertyName}', but got '{txtName?.Name}'");
-          var newtonIgnore = prop.GetCustomAttribute<Newtonsoft.Json.JsonIgnoreAttribute>() ;
-          var txtIgnore = prop.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>() ;
+          var newtonIgnore = prop.GetCustomAttribute<Newtonsoft.Json.JsonIgnoreAttribute>();
+          var txtIgnore = prop.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>();
 
           Assert.False(newtonIgnore != null && txtIgnore == null, $"{t.FullName}.{prop.Name} only has a Newtonsoft.Json.JsonIgnoreAttribute");
           Assert.False(txtIgnore != null && newtonIgnore == null, $"{t.FullName}.{prop.Name} only has a System.Text.Json.Serialization.JsonIgnoreAttribute");

--- a/src/GeocodeSharp.Tests/Serialization/SerializationTest.cs
+++ b/src/GeocodeSharp.Tests/Serialization/SerializationTest.cs
@@ -1,0 +1,32 @@
+﻿using GeocodeSharp.Google;
+using System.Reflection;
+using Xunit;
+
+namespace GeocodeSharp.Tests.Serialization {
+  public class SerializationTest {
+    [Fact]
+    public void TestJsonPropertyNames() {
+      var allTypes = typeof(AddressComponent).Assembly.GetTypes();
+
+      foreach (var t in allTypes) {
+        foreach (var prop in t.GetProperties()) {
+          var newtonName = prop.GetCustomAttribute<Newtonsoft.Json.JsonPropertyAttribute>();
+          var txtName = prop.GetCustomAttribute<System.Text.Json.Serialization.JsonPropertyNameAttribute>();
+
+          // These tests are pretty ugly, but looping through all the properties of the models ensure that we
+          // have matching Newtonsoft and System.Text.Json attributes for every proeprty
+          Assert.False(newtonName != null && txtName == null, $"{t.FullName}.{prop.Name} only has a Newtonsoft.Json.JsonPropertyAttribute");
+          Assert.False(txtName != null && newtonName == null, $"{t.FullName}.{prop.Name} only has a System.Text.Json.Serialization.JsonPropertyNameAttribute");
+          Assert.True(newtonName?.PropertyName == txtName?.Name, $"{t.FullName}.{prop.Name} expected '{newtonName?.PropertyName}', but got '{txtName?.Name}'");
+          var newtonIgnore = prop.GetCustomAttribute<Newtonsoft.Json.JsonIgnoreAttribute>() ;
+          var txtIgnore = prop.GetCustomAttribute<System.Text.Json.Serialization.JsonIgnoreAttribute>() ;
+
+          Assert.False(newtonIgnore != null && txtIgnore == null, $"{t.FullName}.{prop.Name} only has a Newtonsoft.Json.JsonIgnoreAttribute");
+          Assert.False(txtIgnore != null && newtonIgnore == null, $"{t.FullName}.{prop.Name} only has a System.Text.Json.Serialization.JsonIgnoreAttribute");
+        }
+      }
+
+    }
+
+  }
+}

--- a/src/GeocodeSharp/GeocodeSharp.csproj
+++ b/src/GeocodeSharp/GeocodeSharp.csproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1,]" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/src/GeocodeSharp/Google/AddressComponent.cs
+++ b/src/GeocodeSharp/Google/AddressComponent.cs
@@ -1,16 +1,17 @@
 ﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace GeocodeSharp.Google
 {
     public class AddressComponent
     {
-        [JsonProperty("long_name")]
+        [JsonProperty("long_name"), JsonPropertyName("long_name")]
         public string LongName { get; set; }
 
-        [JsonProperty("short_name")]
+        [JsonProperty("short_name"), JsonPropertyName("short_name")]
         public string ShortName { get; set; }
 
-        [JsonProperty("types")]
+        [JsonProperty("types"), JsonPropertyName("types")]
         public string[] Types { get; set; }
     }
 }

--- a/src/GeocodeSharp/Google/GeoCoordinate.cs
+++ b/src/GeocodeSharp/Google/GeoCoordinate.cs
@@ -1,13 +1,14 @@
 ﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace GeocodeSharp.Google
 {
     public class GeoCoordinate
     {
-        [JsonProperty("lat")]
+        [JsonProperty("lat"), JsonPropertyName("lat")]
         public double Latitude { get; set; }
 
-        [JsonProperty("lng")]
+        [JsonProperty("lng"), JsonPropertyName("lng")]
         public double Longitude { get; set; }
     }
 }

--- a/src/GeocodeSharp/Google/GeoViewport.cs
+++ b/src/GeocodeSharp/Google/GeoViewport.cs
@@ -1,13 +1,14 @@
 ﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace GeocodeSharp.Google
 {
     public class GeoViewport
     {
-        [JsonProperty("northeast")]
+        [JsonProperty("northeast"), JsonPropertyName("northeast")]
         public GeoCoordinate Northeast { get; set; }
 
-        [JsonProperty("southwest")]
+        [JsonProperty("southwest"), JsonPropertyName("southwest")]
         public GeoCoordinate Southwest { get; set; }
     }
 }

--- a/src/GeocodeSharp/Google/GeocodeResponse.cs
+++ b/src/GeocodeSharp/Google/GeocodeResponse.cs
@@ -1,13 +1,14 @@
 ﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace GeocodeSharp.Google
 {
     public class GeocodeResponse
     {
-        [JsonProperty("results")]
+        [JsonProperty("results"), JsonPropertyName("results")]
         public GeocodeResult[] Results { get; set; }
 
-        [JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore, System.Text.Json.Serialization.JsonIgnore]
         public GeocodeStatus Status
         {
             get
@@ -25,7 +26,7 @@ namespace GeocodeSharp.Google
             }
         }
 
-        [JsonProperty("status")]
+        [JsonProperty("status"), JsonPropertyName("status")]
         public string StatusText { get; set; }
     }
 }

--- a/src/GeocodeSharp/Google/GeocodeResult.cs
+++ b/src/GeocodeSharp/Google/GeocodeResult.cs
@@ -1,25 +1,26 @@
 ﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace GeocodeSharp.Google
 {
     public class GeocodeResult
     {
-        [JsonProperty("address_components")]
+        [JsonProperty("address_components"), JsonPropertyName("address_components")]
         public AddressComponent[] AddressComponents { get; set; }
 
-        [JsonProperty("formatted_address")]
+        [JsonProperty("formatted_address"), JsonPropertyName("formatted_address")]
         public string FormattedAddress { get; set; }
 
-        [JsonProperty("geometry")]
+        [JsonProperty("geometry"), JsonPropertyName("geometry")]
         public Geometry Geometry { get; set; }
 
-        [JsonProperty("partial_match")]
+        [JsonProperty("partial_match"), JsonPropertyName("partial_match")]
         public bool PartialMatch { get; set; }
 
-        [JsonProperty("place_id")]
+        [JsonProperty("place_id"), JsonPropertyName("place_id")]
         public string PlaceId { get; set; }
 
-        [JsonProperty("types")]
+        [JsonProperty("types"), JsonPropertyName("types")]
         public string[] Types { get; set; }
     }
 }

--- a/src/GeocodeSharp/Google/Geometry.cs
+++ b/src/GeocodeSharp/Google/Geometry.cs
@@ -1,10 +1,11 @@
 ﻿using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace GeocodeSharp.Google
 {
     public class Geometry
     {
-        [JsonProperty("location")]
+        [JsonProperty("location"), JsonPropertyName("location")]
         public GeoCoordinate Location { get; set; }
 
         public LocationType LocationType
@@ -22,13 +23,13 @@ namespace GeocodeSharp.Google
             }
         }
 
-        [JsonProperty("location_type")]
+        [JsonProperty("location_type"), JsonPropertyName("location_type")]
         public string LocationTypeText { get; set; }
 
-        [JsonProperty("viewport")]
+        [JsonProperty("viewport"), JsonPropertyName("viewport")]
         public GeoViewport Viewport { get; set; }
 
-        [JsonProperty("bounds")]
+        [JsonProperty("bounds"), JsonPropertyName("bounds")]
         public GeoViewport Bounds { get; set; }
     }
 }


### PR DESCRIPTION
As per #20, add support for System.Text.Json attributes

- Add System.Text.Json.Serialization.JsonPropertyName
- Add System.Text.Json.Serialization.JsonIgnoreAttributes
- Add tests to ensure the property names are equal when serializing using either Newtonsoft or System.Text.Json